### PR TITLE
Add tests for output

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,8 +10,10 @@ require (
 )
 
 require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200605160147-a5ece683394c // indirect
 )
 
@@ -21,6 +23,6 @@ require (
 	github.com/mattn/go-runewidth v0.0.13 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/stretchr/testify v1.7.1 // indirect
+	github.com/stretchr/testify v1.7.1
 	golang.org/x/sys v0.0.0-20220406163625-3f8b81556e12 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,7 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 golang.org/x/sys v0.0.0-20180816055513-1c9583448a9c/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20220406163625-3f8b81556e12 h1:QyVthZKMsyaQwBTJE04jdNN0Pp5Fn9Qga0mrgxyERQM=
 golang.org/x/sys v0.0.0-20220406163625-3f8b81556e12/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/output/jsonoutput_test.go
+++ b/output/jsonoutput_test.go
@@ -1,0 +1,147 @@
+// Copyright (C) 2022 Roland Schaer
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+//go:build darwin
+
+package output
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestJSONOutput(t *testing.T) {
+	tests := []struct {
+		name        string
+		monkeyPatch func()
+		method      func(jo JSONOutput)
+		expected    string
+	}{
+		{
+			"All sensors",
+			func() {
+				GetAll = func() map[string]interface{} {
+					return map[string]interface{}{
+						"sensor-1": map[string]interface{}{
+							"key":   "key",
+							"value": "string",
+							"type":  "type",
+						},
+						"sensor-2": map[string]interface{}{
+							"key":   "key",
+							"value": true,
+							"type":  "type",
+						},
+						"sensor-3": map[string]interface{}{
+							"key":   "key",
+							"value": 99,
+							"type":  "type",
+						},
+					}
+				}
+			},
+			func(jo JSONOutput) {
+				jo.All()
+			},
+			`{"sensor-1":{"key":"key","value":"string","type":"type"},"sensor-2":{"key":"key","value":true,"type":"type"},"sensor-3":{"key":"key","value":99,"type":"type"}}`,
+		},
+		{
+			"Battery sensor",
+			func() {
+				GetBattery = func() map[string]interface{} {
+					return getMapForSensor("battery")
+				}
+			},
+			func(jo JSONOutput) {
+				jo.Battery()
+			},
+			`{"battery":{"key":"key","value":"value","type":"type"}}`,
+		},
+		{
+			"Current sensor",
+			func() {
+				GetCurrent = func() map[string]interface{} {
+					return getMapForSensor("current")
+				}
+			},
+			func(jo JSONOutput) {
+				jo.Current()
+			},
+			`{"current":{"key":"key","value":"value","type":"type"}}`,
+		},
+		{
+			"Fans sensor",
+			func() {
+				GetFans = func() map[string]interface{} {
+					return getMapForSensor("fans")
+				}
+			},
+			func(jo JSONOutput) {
+				jo.Fans()
+			},
+			`{"fans":{"key":"key","value":"value","type":"type"}}`,
+		},
+		{
+			"Power sensor",
+			func() {
+				GetPower = func() map[string]interface{} {
+					return getMapForSensor("power")
+				}
+			},
+			func(jo JSONOutput) {
+				jo.Power()
+			},
+			`{"power":{"key":"key","value":"value","type":"type"}}`,
+		},
+		{
+			"Temperature sensor",
+			func() {
+				GetTemperature = func() map[string]interface{} {
+					return getMapForSensor("temperature")
+				}
+			},
+			func(jo JSONOutput) {
+				jo.Temperature()
+			},
+			`{"temperature":{"key":"key","value":"value","type":"type"}}`,
+		},
+		{
+			"Voltage sensor",
+			func() {
+				GetVoltage = func() map[string]interface{} {
+					return getMapForSensor("voltage")
+				}
+			},
+			func(jo JSONOutput) {
+				jo.Voltage()
+			},
+			`{"voltage":{"key":"key","value":"value","type":"type"}}`,
+		},
+	}
+	for _, tt := range tests {
+		var out bytes.Buffer
+		t.Run(tt.name, func(t *testing.T) {
+			tt.monkeyPatch()
+
+			jo := JSONOutput{writer: io.Writer(&out)}
+			tt.method(jo)
+
+			actual := out.String()
+			assert.JSONEq(t, tt.expected, actual)
+		})
+	}
+}

--- a/output/output_test.go
+++ b/output/output_test.go
@@ -1,0 +1,151 @@
+// Copyright (C) 2022 Roland Schaer
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+//go:build darwin
+
+package output
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_deepCopy(t *testing.T) {
+	type args struct {
+		dest map[string]interface{}
+		src  map[string]interface{}
+	}
+	tests := []struct {
+		name     string
+		args     args
+		expected string
+	}{
+		{
+			"Verify dest",
+			args{
+				dest: map[string]interface{}{
+					"key-1": "value-1",
+				},
+				src: map[string]interface{}{
+					"key-2": map[string]interface{}{
+						"key-2-1": "value-2-1",
+					},
+					"key-3": map[string]interface{}{
+						"key-3-1": map[string]interface{}{
+							"key-3-1-1": "value-3-1-1",
+						},
+					},
+				},
+			},
+			`{"key-1":"value-1","key-2":{"key-2-1":"value-2-1"},"key-3":{"key-3-1":{"key-3-1-1":"value-3-1-1"}}}`,
+		},
+		{
+			"Verify empty dest",
+			args{
+				dest: map[string]interface{}{},
+				src: map[string]interface{}{
+					"key-1": "value-1",
+					"key-2": map[string]interface{}{
+						"key-2-1": "value-2-1",
+					},
+				},
+			},
+			`{"key-1":"value-1","key-2":{"key-2-1":"value-2-1"}}`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			deepCopy(tt.args.dest, tt.args.src)
+
+			actual := toJson(tt.args.dest)
+			assert.JSONEq(t, actual, tt.expected)
+		})
+	}
+}
+
+func Test_merge(t *testing.T) {
+	type args struct {
+		a map[string]interface{}
+		b map[string]interface{}
+	}
+	tests := []struct {
+		name     string
+		args     args
+		expected map[string]interface{}
+	}{
+		{
+			"Verify merge",
+			args{
+				map[string]interface{}{
+					"key-1": "value-1-a",
+					"key-3": map[string]interface{}{
+						"key-3-2": map[string]interface{}{
+							"key-3-2-1": "value-3-2-1-a",
+						},
+					},
+				},
+				map[string]interface{}{
+					"key-1": "value-2-b",
+					"key-2": "value-2-b",
+					"key-3": map[string]interface{}{
+						"key-3-1": "value-3-1-b",
+						"key-3-2": map[string]interface{}{
+							"key-3-2-1": "value-3-2-1-b",
+						},
+					},
+				},
+			},
+			map[string]interface{}{
+				"key-1": "value-2-b",
+				"key-2": "value-2-b",
+				"key-3": map[string]interface{}{
+					"key-3-1": "value-3-1-b",
+					"key-3-2": map[string]interface{}{
+						"key-3-2-1": "value-3-2-1-b",
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := merge(tt.args.a, tt.args.b)
+			assert.True(
+				t,
+				reflect.DeepEqual(actual, tt.expected),
+				fmt.Sprintf("Expected %v but was %v", tt.expected, actual),
+			)
+		})
+	}
+}
+
+func toJson(src map[string]interface{}) string {
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	jsonStr, _ := json.Marshal(src)
+	return string(jsonStr)
+}
+
+func getMapForSensor(sensorName string) map[string]interface{} {
+	return map[string]interface{}{
+		sensorName: map[string]interface{}{
+			"key":   "key",
+			"value": "value",
+			"type":  "type",
+		},
+	}
+}

--- a/output/outputfactory_test.go
+++ b/output/outputfactory_test.go
@@ -1,0 +1,57 @@
+// Copyright (C) 2022 Roland Schaer
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package output
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestOutputFactory(t *testing.T) {
+	type args struct {
+		outputType string
+	}
+	tests := []struct {
+		name string
+		args args
+		want Output
+	}{
+		{
+			"Returns TableOutput(ASCII) for ascii output type",
+			args{outputType: "ascii"},
+			NewTableOutput(true),
+		}, {
+			"Returns TableOutput for table output type",
+			args{outputType: "table"},
+			NewTableOutput(false),
+		}, {
+
+			"Returns JSONOutput for table output type",
+			args{outputType: "json"},
+			NewJSONOutput(),
+		}, {
+			"Returns TableOutput for unknown output type",
+			args{outputType: ""},
+			NewTableOutput(false),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := OutputFactory(tt.args.outputType); reflect.TypeOf(got) != reflect.TypeOf(tt.want) {
+				t.Errorf("OutputFactory() = %v, want %v", reflect.TypeOf(got), reflect.TypeOf(tt.want))
+			}
+		})
+	}
+}

--- a/output/tableoutput.go
+++ b/output/tableoutput.go
@@ -50,8 +50,9 @@ func (to TableOutput) All() {
 
 	for _, key := range keys {
 		value := all[key]
-		smcdata := value.(map[string]interface{})
-		to.print(key, smcdata)
+		if smcdata, ok := value.(map[string]interface{}); ok {
+			to.print(key, smcdata)
+		}
 	}
 }
 
@@ -98,13 +99,14 @@ func (to TableOutput) print(name string, smcdata map[string]interface{}) {
 
 		for _, k := range keys {
 			v := smcdata[k]
-			value := v.(map[string]interface{})
-			t.AppendRow([]interface{}{
-				fmt.Sprintf("%v", k),
-				value["key"],
-				fmt.Sprintf("%8v", value["value"]),
-				value["type"],
-			})
+			if value, ok := v.(map[string]interface{}); ok {
+				t.AppendRow([]interface{}{
+					fmt.Sprintf("%v", k),
+					value["key"],
+					fmt.Sprintf("%8v", value["value"]),
+					value["type"],
+				})
+			}
 		}
 
 		t.Render()

--- a/output/tableoutput_test.go
+++ b/output/tableoutput_test.go
@@ -1,0 +1,247 @@
+// Copyright (C) 2022 Roland Schaer
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+//go:build darwin
+
+package output
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var asciiTpl = `+-------------------------------------+
+|%s|
++-------------+-----+----------+------+
+| DESCRIPTION | KEY | VALUE    | TYPE |
++-------------+-----+----------+------+
+| sensor      | key |    value | type |
++-------------+-----+----------+------+
+
+`
+
+var tableTpl = `[96;100;1m%s[0m
+[106;30m DESCRIPTION [0m[106;30m KEY [0m[106;30m VALUE    [0m[106;30m TYPE [0m
+[107;30m sensor      [0m[107;30m key [0m[107;30m    value [0m[107;30m type [0m
+
+`
+
+func TestTableOutput_ASCII(t *testing.T) {
+	tests := []struct {
+		name        string
+		monkeyPatch func()
+		method      func(to TableOutput)
+		expected    string
+	}{
+		{
+			"All sensors",
+			func() {
+				GetAll = func() map[string]interface{} {
+					return map[string]interface{}{
+						"battery": map[string]interface{}{
+							"sensor": map[string]interface{}{
+								"key":   "key",
+								"value": "value",
+								"type":  "type",
+							},
+						},
+						"fans": map[string]interface{}{
+							"sensor": map[string]interface{}{
+								"key":   "key",
+								"value": "value",
+								"type":  "type",
+							},
+						},
+						"temperature": map[string]interface{}{
+							"sensor": map[string]interface{}{
+								"key":   "key",
+								"value": "value",
+								"type":  "type",
+							},
+						},
+					}
+				}
+			},
+			func(to TableOutput) {
+				to.All()
+			},
+			getAsciiTpl("battery", "fans", "temperature"),
+		},
+		{
+			"Battery sensor",
+			func() {
+				GetBattery = func() map[string]interface{} {
+					return getMapForSensor("sensor")
+				}
+			},
+			func(to TableOutput) {
+				to.Battery()
+			},
+			getAsciiTpl("Battery"),
+		},
+		{
+			"Current sensor",
+			func() {
+				GetCurrent = func() map[string]interface{} {
+					return getMapForSensor("sensor")
+				}
+			},
+			func(to TableOutput) {
+				to.Current()
+			},
+			getAsciiTpl("Current"),
+		},
+		{
+			"Fans sensor",
+			func() {
+				GetFans = func() map[string]interface{} {
+					return getMapForSensor("sensor")
+				}
+			},
+			func(to TableOutput) {
+				to.Fans()
+			},
+			getAsciiTpl("Fans"),
+		},
+		{
+			"Power sensor",
+			func() {
+				GetPower = func() map[string]interface{} {
+					return getMapForSensor("sensor")
+				}
+			},
+			func(to TableOutput) {
+				to.Power()
+			},
+			getAsciiTpl("Power"),
+		},
+		{
+			"Temperature sensor",
+			func() {
+				GetTemperature = func() map[string]interface{} {
+					return getMapForSensor("sensor")
+				}
+			},
+			func(to TableOutput) {
+				to.Temperature()
+			},
+			getAsciiTpl("Temperature"),
+		},
+		{
+			"Voltage sensor",
+			func() {
+				GetVoltage = func() map[string]interface{} {
+					return getMapForSensor("sensor")
+				}
+			},
+			func(to TableOutput) {
+				to.Voltage()
+			},
+			getAsciiTpl("Voltage"),
+		},
+	}
+	for _, tt := range tests {
+		var out bytes.Buffer
+		t.Run(tt.name, func(t *testing.T) {
+			tt.monkeyPatch()
+
+			to := TableOutput{isASCII: true, writer: io.Writer(&out)}
+			tt.method(to)
+
+			actual := out.String()
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
+func TestTableOutput_Table(t *testing.T) {
+	tests := []struct {
+		name        string
+		monkeyPatch func()
+		method      func(to TableOutput)
+		expected    string
+	}{
+		{
+			"All sensors",
+			func() {
+				GetAll = func() map[string]interface{} {
+					return map[string]interface{}{
+						"battery": map[string]interface{}{
+							"sensor": map[string]interface{}{
+								"key":   "key",
+								"value": "value",
+								"type":  "type",
+							},
+						},
+						"fans": map[string]interface{}{
+							"sensor": map[string]interface{}{
+								"key":   "key",
+								"value": "value",
+								"type":  "type",
+							},
+						},
+					}
+				}
+			},
+			func(to TableOutput) {
+				to.All()
+			},
+			getTableTpl("battery", "fans"),
+		},
+	}
+	for _, tt := range tests {
+		var out bytes.Buffer
+		t.Run(tt.name, func(t *testing.T) {
+			tt.monkeyPatch()
+
+			to := TableOutput{isASCII: false, writer: io.Writer(&out)}
+			tt.method(to)
+
+			actual := out.String()
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
+func getAsciiTpl(title ...string) string {
+	var out string
+	for _, t := range title {
+		// center title
+		width := 37
+		even := 0
+		if len(t)%2 == 0 {
+			even = 1
+		}
+		centeredTitle := fmt.Sprintf("%*s", -width, fmt.Sprintf("%*s", (width+len(t)+even)/2, t))
+
+		out += fmt.Sprintf(asciiTpl, centeredTitle)
+	}
+	return out
+}
+
+func getTableTpl(title ...string) string {
+	var out string
+	for _, t := range title {
+		// center title
+		width := 35
+		centeredTitle := fmt.Sprintf("%*s", -width+1, fmt.Sprintf("%*s", (width+len(t))/2, t))
+
+		out += fmt.Sprintf(tableTpl, centeredTitle)
+	}
+	return out
+}


### PR DESCRIPTION
Adding some tests for the output package. Some tests are still missing for `output.go` which would require more monkey patching since neither `smc` nor `hid` use any interfaces that could be easily mocked.