### PR TITLE
'go get' is no longer supported outside a module

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ There are two ways of installing `iSMC` (tool works only on macOS computers):
 
 Download your preferred flavor from [the releases](https://github.com/dkorunic/iSMC/releases/latest) page and install manually.
 
-### Using go get
+### Using go install
 
 ```shell
-CGO_ENABLED=1 go get github.com/dkorunic/iSMC
+CGO_ENABLED=1 go install github.com/dkorunic/iSMC@latest
 ```
 
 ## Usage


### PR DESCRIPTION
❯ CGO_ENABLED=1 go get github.com/dkorunic/iSMC
go: go.mod file not found in current directory or any parent directory.
	'go get' is no longer supported outside a module.
	To build and install a command, use 'go install' with a version,
	like 'go install example.com/cmd@latest'
	For more information, see https://golang.org/doc/go-get-install-deprecation
	or run 'go help get' or 'go help install'.