### PR TITLE
Fix temperature sensor reading errors

### DIFF
--- a/hid/get.go
+++ b/hid/get.go
@@ -133,7 +133,15 @@ NSString *dumpNamesValues(NSArray *kvsN, NSArray *kvsV) {
     int             count = [kvsN count];
 
     for (int i = 0; i < count; i++) {
-        NSString *output = [NSString stringWithFormat:@"%s:%lf\n", [kvsN[i] UTF8String], [kvsV[i] doubleValue]];
+        NSString *name = kvsN[i];
+        double   value = [kvsV[i] doubleValue];
+
+        // Some HID thermal sensors (e.g., tdev) use sp78 format and need conversion
+        if ([name containsString:@"tdev"]) {
+            value = value / 256.0;
+        }
+
+        NSString *output = [NSString stringWithFormat:@"%s:%lf\n", [name UTF8String], value];
         [valueString appendString:output];
     }
 

--- a/hid/get.go
+++ b/hid/get.go
@@ -136,9 +136,34 @@ NSString *dumpNamesValues(NSArray *kvsN, NSArray *kvsV) {
         NSString *name = kvsN[i];
         double   value = [kvsV[i] doubleValue];
 
-        // Some HID thermal sensors (e.g., tdev) use sp78 format and need conversion
-        if ([name containsString:@"tdev"]) {
-            value = value / 256.0;
+        NSString *output = [NSString stringWithFormat:@"%s:%lf\n", [name UTF8String], value];
+        [valueString appendString:output];
+    }
+
+    return valueString;
+}
+
+// dumpThermalNamesValues formats thermal sensor names and values, applying sp78 conversion
+// for specific HID thermal sensors that use the sp78 fixed-point format (e.g., PMU tdev sensors)
+static NSString *dumpThermalNamesValues(NSArray *kvsN, NSArray *kvsV) {
+    NSMutableString *valueString = [[NSMutableString alloc] init];
+    int             count = [kvsN count];
+
+    for (int i = 0; i < count; i++) {
+        NSString *name = kvsN[i];
+        double   value = [kvsV[i] doubleValue];
+
+        // PMU tdev sensors (e.g., "PMU tdev1") use sp78 format and need /256 conversion
+        // Check for "tdev" followed by a digit to avoid false matches
+        NSRange range = [name rangeOfString:@"tdev"];
+        if (range.location != NSNotFound) {
+            // Verify the pattern is "tdev" followed by a number (e.g., "tdev1", "PMU tdev2")
+            if (range.location + 4 < [name length]) {
+                unichar nextChar = [name characterAtIndex:range.location + 4];
+                if (nextChar >= '1' && nextChar <= '9') {
+                    value = value / 256.0;
+                }
+            }
         }
 
         NSString *output = [NSString stringWithFormat:@"%s:%lf\n", [name UTF8String], value];
@@ -182,7 +207,7 @@ char *getThermals() {
     NSDictionary    *thermalSensors = matching(0xff00, 5);
     NSArray         *thermalNames = getProductNames(thermalSensors);
     NSArray         *thermalValues = getThermalValues(thermalSensors);
-    NSString        *result = dumpNamesValues(thermalNames, thermalValues);
+    NSString        *result = dumpThermalNamesValues(thermalNames, thermalValues);
     char            *finalStr = strdup([result UTF8String]);
 
     CFRelease(thermalSensors);

--- a/smc/get.go
+++ b/smc/get.go
@@ -31,12 +31,15 @@ func getKeyFloat32(c uint, key string) (float32, string, error) {
 
 	t := smcTypeToString(v.DataType)
 
-	// Ta0P is mislabeled as 'flt' but actually uses 'sp78' format (2-byte fixed-point)
+	// Some sensors are mislabeled as 'flt' but actually use 'sp78' format (2-byte fixed-point)
 	// The first 2 bytes contain the sp78 value
-	if key == "Ta0P" && t == gosmc.TypeFLT && v.DataSize >= 2 {
-		// Read first 2 bytes as big-endian int16 and convert to sp78 format
-		raw := uint16(v.Bytes[0])<<8 | uint16(v.Bytes[1])
-		return float32(int16(raw)) / 256.0, t, nil
+	// Ta0P is known to be affected on M1/M2 Macs
+	if t == gosmc.TypeFLT && v.DataSize >= 2 {
+		if key == "Ta0P" {
+			// Read first 2 bytes as big-endian int16 and convert to sp78 format
+			raw := uint16(v.Bytes[0])<<8 | uint16(v.Bytes[1])
+			return float32(int16(raw)) / 256.0, t, nil
+		}
 	}
 
 	switch t {

--- a/smc/get.go
+++ b/smc/get.go
@@ -30,6 +30,15 @@ func getKeyFloat32(c uint, key string) (float32, string, error) {
 	}
 
 	t := smcTypeToString(v.DataType)
+
+	// Ta0P is mislabeled as 'flt' but actually uses 'sp78' format (2-byte fixed-point)
+	// The first 2 bytes contain the sp78 value
+	if key == "Ta0P" && t == gosmc.TypeFLT && v.DataSize >= 2 {
+		// Read first 2 bytes as big-endian int16 and convert to sp78 format
+		raw := uint16(v.Bytes[0])<<8 | uint16(v.Bytes[1])
+		return float32(int16(raw)) / 256.0, t, nil
+	}
+
 	switch t {
 	// flt SMC type
 	case gosmc.TypeFLT:

--- a/smc/sensors.go
+++ b/smc/sensors.go
@@ -250,6 +250,8 @@ var AppleTemp = []SensorStat{
 	{Key: "Tp2h", Desc: "Power Supply T2 Secondary Heatsink Raw"},
 	{Key: "Ts1P", Desc: "Actuator"},
 	{Key: "Ts1S", Desc: "Synthetic Top Skin"},
+	{Key: "TaLT", Desc: "Thunderbolt Left Proximity"},
+	{Key: "TaRT", Desc: "Thunderbolt Right Proximity"},
 	{Key: "TTLD", Desc: "Thunderbolt Left"},
 	{Key: "TTRD", Desc: "Thunderbolt Right"},
 }

--- a/smc/sensors.go
+++ b/smc/sensors.go
@@ -250,12 +250,11 @@ var AppleTemp = []SensorStat{
 	{Key: "Tp2h", Desc: "Power Supply T2 Secondary Heatsink Raw"},
 	{Key: "Ts1P", Desc: "Actuator"},
 	{Key: "Ts1S", Desc: "Synthetic Top Skin"},
-	{Key: "TaLT", Desc: "Thunderbolt Left Proximity"},
-	{Key: "TaRT", Desc: "Thunderbolt Right Proximity"},
 	{Key: "TTLD", Desc: "Thunderbolt Left"},
 	{Key: "TTRD", Desc: "Thunderbolt Right"},
+	{Key: "TaLT", Desc: "Thunderbolt Left Proximity"},
+	{Key: "TaRT", Desc: "Thunderbolt Right Proximity"},
 }
-
 var AppleFans = []SensorStat{
 	{Key: "F%dAc", Desc: "Fan %d Current Speed"},
 	{Key: "F%dMn", Desc: "Fan %d Minimal Speed"},
@@ -263,7 +262,6 @@ var AppleFans = []SensorStat{
 	{Key: "F%dSf", Desc: "Fan %d Safe Speed"},
 	{Key: "F%dTg", Desc: "Fan %d Target Speed"},
 }
-
 var ApplePower = []SensorStat{
 	{Key: "PC%C", Desc: "CPU Core %"},
 	{Key: "PCAM", Desc: "CPU Core (IMON)"},
@@ -395,7 +393,6 @@ var ApplePower = []SensorStat{
 	{Key: "PU1R", Desc: "Thunderbolt Left"},
 	{Key: "PU2R", Desc: "Thunderbolt Right"},
 }
-
 var AppleVoltage = []SensorStat{
 	{Key: "VCAC", Desc: "CPU IA"},
 	{Key: "VCSC", Desc: "CPU System Agent"},
@@ -455,7 +452,6 @@ var AppleVoltage = []SensorStat{
 	{Key: "VZHD", Desc: "SSD"},
 	{Key: "VZOD", Desc: "ODD"},
 }
-
 var AppleCurrent = []SensorStat{
 	{Key: "IC0C", Desc: "CPU Core"},
 	{Key: "IC1C", Desc: "CPU VccIO"},

--- a/src/temp.txt
+++ b/src/temp.txt
@@ -230,3 +230,5 @@ Actuator:Ts1P
 Synthetic Top Skin:Ts1S
 Thunderbolt Left:TTLD
 Thunderbolt Right:TTRD
+Thunderbolt Left Proximity:TaLT
+Thunderbolt Right Proximity:TaRT


### PR DESCRIPTION
- Fix PMU tdev HID sensors showing ~9200°C (sp78 format needs /256)
- Fix DCIn Air Flow Ta0P showing 8°C (mislabeled as 'flt', actually sp78)
- Add Thunderbolt Left/Right Proximity (TaLT/TaRT) sensors for M-series Macs